### PR TITLE
Layout Fix

### DIFF
--- a/TTSwitch/TTSwitch.m
+++ b/TTSwitch/TTSwitch.m
@@ -98,6 +98,10 @@ static const CGFloat kTTSwitchAnimationDuration = 0.25;
 
 - (void)layoutSubviews
 {
+    _maskedTrackView.frame = self.bounds;
+    _maskedThumbView.frame = self.bounds;
+    _trackMaskLayer.frame = self.bounds;
+    
     [super layoutSubviews];
 
     if (self.onString.length > 0) {


### PR DESCRIPTION
Fixed a layout issue I was having when using the TTSwitch in a storyboard. The control was initialized with a frame of 0,0,0,0 and was later changed but some of the subviews were not getting updated.
